### PR TITLE
Update pfc_w_zoom.srw

### DIFF
--- a/pfcdwsrv/pfc_w_zoom.srw
+++ b/pfcdwsrv/pfc_w_zoom.srw
@@ -8,6 +8,7 @@ end type
 type rb_200 from u_rb within pfc_w_zoom
 end type
 type rb_100 from u_rb within pfc_w_zoom
+boolean checked = true
 end type
 type rb_75 from u_rb within pfc_w_zoom
 end type


### PR DESCRIPTION
Added checked to rb_100 to prevent error crash caused by some obscure change in PB 2017. It appears that it requires at least one radio button in a group to be checked. Setting the 100% button as default fixes the problem in this window.